### PR TITLE
[infra] try to reconnect Redis before query execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,5 @@ members = [
 ]
 
 [workspace.package]
-name = "clockwork-orange"
 version = "0.1.0"
 authors = ["Vlad Stepanov <me@utterstep.dev>"]


### PR DESCRIPTION
Currently this is done by simply running the `PING` query and repeating it in case of any error